### PR TITLE
fix riscv64 makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ EXE=$(NAME)$(shell go env GOEXE)
 DATE=$(shell date '+%F-%T')
 BRANCH=$(shell git symbolic-ref HEAD | cut -d"/" -f 3)
 COMMIT=$(shell git rev-parse HEAD | cut -c1-7)
-VERSIONNUMBER="1.0.1"
+VERSIONNUMBER="1.0.2"
 VERSION=$(NAME)--"Agent-"$(VERSIONNUMBER)--$(DATE)-$(BRANCH)-$(COMMIT)
 LDFLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}' -X 'main.VersionNumber=${VERSIONNUMBER}'"
 SOURCES=$(shell ls **/*.go)

--- a/Makefile.amd64
+++ b/Makefile.amd64
@@ -18,7 +18,7 @@ DATE=$(shell date '+%F-%T')
 BRANCH=$(shell git symbolic-ref HEAD | cut -d"/" -f 3)
 COMMIT=$(shell git rev-parse HEAD | cut -c1-7)
 ARCH ?= amd64
-VERSIONNUMBER="1.0.1"
+VERSIONNUMBER="1.0.2"
 VERSION=$(NAME)--"Agent-"$(VERSIONNUMBER)--$(DATE)-$(BRANCH)-$(COMMIT)
 LDFLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}' -X 'main.VersionNumber=${VERSIONNUMBER}'"
 SOURCES=$(shell ls **/*.go)

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -18,7 +18,7 @@ DATE=$(shell date '+%F-%T')
 BRANCH=$(shell git symbolic-ref HEAD | cut -d"/" -f 3)
 COMMIT=$(shell git rev-parse HEAD | cut -c1-7)
 ARCH ?= riscv64
-VERSIONNUMBER="1.0.1"
+VERSIONNUMBER="1.0.2"
 VERSION=$(NAME)--"Agent-"$(VERSIONNUMBER)--$(DATE)-$(BRANCH)-$(COMMIT)
 LDFLAGS=-ldflags "-s -w -X 'main.Version=${VERSION}' -X 'main.VersionNumber=${VERSIONNUMBER}'"
 SOURCES=$(shell ls **/*.go)

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -28,12 +28,10 @@ all: exe
 
 .PHONY: exe
 exe: $(SOURCES) Makefile
-        echo "building..."
-        #swag init -g biz/web/http_server.go
-        go env -w GO111MODULE=on
-        go env -w GOPROXY="https://goproxy.io,direct"
-        # GOOS=linux GOARCH=${ARCH} go build $(OPTIONS) $(LDFLAGS) -o build/$(NAME)
-        go build $(OPTIONS) $(LDFLAGS) -o build/$(NAME)
+    echo "building..."
+    go env -w GO111MODULE=on
+    go env -w GOPROXY="https://goproxy.io,direct"
+    go build $(OPTIONS) $(LDFLAGS) -o build/$(NAME)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
fix this error:

Makefile.riscv64:31: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.