### PR TITLE
单容器时局域网内网关接口端口号改成 80/443

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -524,11 +524,13 @@ func modifyConfigWhenRunInDocker() {
 				*v = strings.ReplaceAll(*v, "localhost:8080", "aospace-gateway:8080")
 				*v = strings.ReplaceAll(*v, "127.0.0.1:6379", "aospace-redis:6379")
 			}
-		}
+			Config.GateWay.LanPort = 12841
+			Config.GateWay.TlsLanPort = 18569
 
-		// All
-		Config.GateWay.LanPort = 12841
-		Config.GateWay.TlsLanPort = 18569
+		} else {
+			Config.GateWay.LanPort = 80
+			Config.GateWay.TlsLanPort = 443
+		}
 
 	}
 	// fmt.Printf("######################## Config.Log.Path:%v\n",


### PR DESCRIPTION
单容器时 Android/iOS 端 APP 的局域网内端口号访问的是 80/443。