### PR TITLE
 improve logging and simplify deployment routing behavior

### DIFF
--- a/biz/docker/docker.go
+++ b/biz/docker/docker.go
@@ -63,9 +63,11 @@ var eventLoopNormal *simpleeventbus.EventLoop
 var tickerStartProgress *time.Ticker
 
 func init() {
-	writeDefaultDockerComposeFile()
-	if hardware.RunningInDocker() {
-		writeUpgradeComposeFile()
+	if config.Config.EnableDockerManage {
+		writeDefaultDockerComposeFile()
+		if hardware.RunningInDocker() {
+			writeUpgradeComposeFile()
+		}
 	}
 }
 

--- a/biz/docker/docker_dispose_compose_file.go
+++ b/biz/docker/docker_dispose_compose_file.go
@@ -20,184 +20,183 @@
  * @Description:
  */
 
- package docker
+package docker
 
- import (
-	 "agent/biz/model/device"
-	 "agent/biz/model/disk_initial/model"
-	 "agent/config"
-	 "agent/res"
-	 "fmt"
-	 math_rand "math/rand"
-	 "strings"
-	 "time"
- 
-	 "agent/utils/logger"
- 
-	 "github.com/dungeonsnd/gocom/file/fileutil"
- )
- 
- func replacePlaceholderInComposeFile(f string) error {
-	 logger.AppLogger().Debugf("replacePlaceholderInComposeFile, f:%v", f)
- 
-	 btid := device.GetDeviceInfo().Btid
- 
-	 b, err := fileutil.ReadFromFile(f)
-	 if err != nil {
-		 logger.AppLogger().Debugf("replacePlaceholderInComposeFile, failed ReadFromFile f:%v", f)
-		 return err
-	 }
-	 s := string(b)
-	 logger.AppLogger().Debugf("replacePlaceholderInComposeFile, %v", f)
-	 s = strings.ReplaceAll(s, config.Config.Box.Loki.Placeholder, btid)
-	 // logger.AppLogger().Debugf("replacePlaceholderInComposeFile, after Replace placeholder %v new content: %v", f, s)
-	 newContent := []byte(s)
-	 err = fileutil.WriteToFile(f, newContent, true)
-	 if err != nil {
-		 logger.AppLogger().Warnf("replacePlaceholderInComposeFile, failed WriteToFile %v", f)
-		 return err
-	 }
-	 logger.AppLogger().Debugf("replacePlaceholderInComposeFile, succ WriteToFile %v", f)
-	 return nil
- }
- 
- func disposeComposeFile() {
-	 f := config.Config.Docker.CustomComposeFile
-	 logger.AppLogger().Debugf("disposeComposeFile, f:%v", f)
-	 replacePlaceholderInComposeFile(f)
-	 if fileutil.IsFileExist(f) {
-		 logger.AppLogger().Infof("DisposeComposeFile, %v exist", f)
-		 b, err := fileutil.ReadFromFile(f)
-		 if err != nil {
-			 logger.AppLogger().Warnf("failed ReadFromFile, file:%v, err:%v", f, err)
-		 } else {
-			 err1 := fileutil.WriteToFile(config.Config.Docker.ComposeFile,
-				 b, true)
-			 if err1 != nil {
-				 logger.AppLogger().Warnf("failed WriteToFile, file:%v, err1:%v", config.Config.Docker.ComposeFile, err1)
-			 }
-		 }
-	 } else {
-		 logger.AppLogger().Warnf("DisposeComposeFile, %v not exist", f)
-	 }
- 
-	 err := ProcessVolumes(config.Config.Docker.ComposeFile, model.GetFileStoragePath())
-	 if err != nil {
-		 logger.AppLogger().Warnf("failed ProcessVolumes, file:%v, err1:%v", config.Config.Docker.ComposeFile, err)
-	 }
- }
- 
- func writeDefaultDockerComposeFile() {
-	 // rpm 安装时已经不释放了，所以须在程序里释放。升级时已经有该文件了，所以启动时根据配置项释放程序中内置的。
-	 if fileutil.IsFileNotExist(config.Config.Docker.CustomComposeFile) {
-		 fmt.Printf("writeDefaultDockerComposeFile, %v not exist\n", config.Config.Docker.CustomComposeFile)
- 
-		 composeFileContent := res.GetContentDockerCompose()
-		 composeFileContent = replaceRandomPasswordAndPortPlaceholder(composeFileContent)
-		 fileutil.WriteToFile(config.Config.Docker.CustomComposeFile, composeFileContent, true)
-	 } else {
-		 fmt.Printf("writeDefaultDockerComposeFile, %v exist\n", config.Config.Docker.CustomComposeFile)
- 
-		 if config.Config.OverwriteDockerCompose {
-			 composeFileContent := res.GetContentDockerCompose()
-			 composeFileContent = replaceRandomPasswordAndPortPlaceholder(composeFileContent)
-			 fileutil.WriteToFile(config.Config.Docker.CustomComposeFile, composeFileContent, true)
-		 }
-	 }
- }
- 
- func writeUpgradeComposeFile() {
-	 f := config.Config.Docker.UpgradeComposeFile
-	 logger.AppLogger().Debugf("dispose upgrade ComposeFile, f:%v", f)
-	 composeFileContent := res.GetContentUpgradeComposeFile()
-	 err := fileutil.WriteToFile(f, composeFileContent, true)
-	 if err != nil {
-		 logger.AppLogger().Errorf("write upgrade ComposeFile err:%v", err)
-		 return
-	 }
- }
- 
- func replaceRandomPasswordAndPortPlaceholder(composeFileContent []byte) []byte {
-	 logger.AppLogger().Debugf("replaceRandomPasswordAndPortPlaceholder")
- 
-	 randstr := ""
-	 if fileutil.IsFileExist(config.Config.Box.RandDockercomposePassword) {
- 
-		 b, err := fileutil.ReadFromFile(config.Config.Box.RandDockercomposePassword)
-		 if err != nil {
-			 logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, ReadFromFile %v err: %v",
-				 config.Config.Box.RandDockercomposePassword, err)
-		 } else {
-			 randstr = string(b)
-		 }
-	 }
-	 if len(randstr) < 2 {
-		 // 替换成随机密码
-		 randstr = rand(16)
-		 err := fileutil.WriteToFile(config.Config.Box.RandDockercomposePassword, []byte(randstr), true)
-		 if err != nil {
-			 logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, WriteToFile %v err: %v",
-				 config.Config.Box.RandDockercomposePassword, err)
-		 }
-	 }
-	 logger.AppLogger().Debugf("replaceRandomPasswordAndPortPlaceholder, randstr:%v", randstr)
-	 composeFileContent = []byte(strings.ReplaceAll(string(composeFileContent), "placeholder_mysecretpassword", randstr))
- 
-	 randRedisPort := ""
-	 if fileutil.IsFileExist(config.Config.Box.RandDockercomposeRedisPort) {
- 
-		 b, err := fileutil.ReadFromFile(config.Config.Box.RandDockercomposeRedisPort)
-		 if err != nil {
-			 logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, ReadFromFile %v err: %v",
-				 config.Config.Box.RandDockercomposeRedisPort, err)
-		 } else {
-			 randRedisPort = string(b)
-			 if err != nil {
-				 logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, strconv.Atoi %v err: %v",
-					 string(b), err)
-			 }
-		 }
-	 }
-	 if len(randRedisPort) < 2 {
-		 // 替换成随机端口号
-		 randRedisPort = randInt(19000, 19999) // redis 端口号在一个区间内随机生成
-		 err := fileutil.WriteToFile(config.Config.Box.RandDockercomposeRedisPort, []byte(randRedisPort), true)
-		 if err != nil {
-			 logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, WriteToFile %v err: %v",
-				 config.Config.Box.RandDockercomposeRedisPort, err)
-		 }
-	 }
- 
-	 i := strings.Index(string(composeFileContent), "placeholder_6379")
-	 logger.AppLogger().Debugf("replaceRandomPasswordAndPortPlaceholder, randRedisPort:%v, strings.Index return :%v", randRedisPort, i)
- 
-	 composeFileContent = []byte(strings.ReplaceAll(string(composeFileContent), "placeholder_6379", randRedisPort))
- 
-	 // 更新自身连接 redis 的配置。
-	 addrSplit := strings.Split(config.Config.Redis.Addr, ":")
-	 if len(addrSplit) > 1 {
-		 config.UpdateRedisConfig(addrSplit[0]+":6379", randstr)
-	 } else {
-		 config.UpdateRedisConfig("127.0.0.1:"+randRedisPort, randstr)
-	 }
- 
-	 return composeFileContent
- }
- 
- func rand(length int) string {
-	 str := "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	 bytes := []byte(str)
-	 result := []byte{}
-	 r := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
-	 for i := 0; i < length; i++ {
-		 result = append(result, bytes[r.Intn(len(bytes))])
-	 }
-	 return string(result)
- }
- 
- func randInt(min int, max int) string {
-	 math_rand.Seed(time.Now().UnixNano())
-	 r := math_rand.Intn(max-min) + min
-	 return fmt.Sprintf("%v", r)
- }
- 
+import (
+	"agent/biz/model/device"
+	"agent/biz/model/disk_initial/model"
+	"agent/config"
+	"agent/res"
+	"fmt"
+	math_rand "math/rand"
+	"strings"
+	"time"
+
+	"agent/utils/logger"
+
+	"github.com/dungeonsnd/gocom/file/fileutil"
+)
+
+func replacePlaceholderInComposeFile(f string) error {
+	logger.AppLogger().Debugf("replacePlaceholderInComposeFile, f:%v", f)
+
+	btid := device.GetDeviceInfo().Btid
+
+	b, err := fileutil.ReadFromFile(f)
+	if err != nil {
+		logger.AppLogger().Debugf("replacePlaceholderInComposeFile, failed ReadFromFile f:%v", f)
+		return err
+	}
+	s := string(b)
+	logger.AppLogger().Debugf("replacePlaceholderInComposeFile, %v", f)
+	s = strings.ReplaceAll(s, config.Config.Box.Loki.Placeholder, btid)
+	// logger.AppLogger().Debugf("replacePlaceholderInComposeFile, after Replace placeholder %v new content: %v", f, s)
+	newContent := []byte(s)
+	err = fileutil.WriteToFile(f, newContent, true)
+	if err != nil {
+		logger.AppLogger().Warnf("replacePlaceholderInComposeFile, failed WriteToFile %v", f)
+		return err
+	}
+	logger.AppLogger().Debugf("replacePlaceholderInComposeFile, succ WriteToFile %v", f)
+	return nil
+}
+
+func disposeComposeFile() {
+	f := config.Config.Docker.CustomComposeFile
+	logger.AppLogger().Debugf("disposeComposeFile, f:%v", f)
+	replacePlaceholderInComposeFile(f)
+	if fileutil.IsFileExist(f) {
+		logger.AppLogger().Infof("DisposeComposeFile, %v exist", f)
+		b, err := fileutil.ReadFromFile(f)
+		if err != nil {
+			logger.AppLogger().Warnf("failed ReadFromFile, file:%v, err:%v", f, err)
+		} else {
+			err1 := fileutil.WriteToFile(config.Config.Docker.ComposeFile,
+				b, true)
+			if err1 != nil {
+				logger.AppLogger().Warnf("failed WriteToFile, file:%v, err1:%v", config.Config.Docker.ComposeFile, err1)
+			}
+		}
+	} else {
+		logger.AppLogger().Warnf("DisposeComposeFile, %v not exist", f)
+	}
+
+	err := ProcessVolumes(config.Config.Docker.ComposeFile, model.GetFileStoragePath())
+	if err != nil {
+		logger.AppLogger().Warnf("failed ProcessVolumes, file:%v, err1:%v", config.Config.Docker.ComposeFile, err)
+	}
+}
+
+func writeDefaultDockerComposeFile() {
+	// rpm 安装时已经不释放了，所以须在程序里释放。升级时已经有该文件了，所以启动时根据配置项释放程序中内置的。
+	if fileutil.IsFileNotExist(config.Config.Docker.CustomComposeFile) {
+		logger.AppLogger().Infof("writeDefaultDockerComposeFile, %v not exist", config.Config.Docker.CustomComposeFile)
+
+		composeFileContent := res.GetContentDockerCompose()
+		composeFileContent = replaceRandomPasswordAndPortPlaceholder(composeFileContent)
+		fileutil.WriteToFile(config.Config.Docker.CustomComposeFile, composeFileContent, true)
+	} else {
+		logger.AppLogger().Infof("writeDefaultDockerComposeFile, %v exist", config.Config.Docker.CustomComposeFile)
+
+		if config.Config.OverwriteDockerCompose {
+			composeFileContent := res.GetContentDockerCompose()
+			composeFileContent = replaceRandomPasswordAndPortPlaceholder(composeFileContent)
+			fileutil.WriteToFile(config.Config.Docker.CustomComposeFile, composeFileContent, true)
+		}
+	}
+}
+
+func writeUpgradeComposeFile() {
+	f := config.Config.Docker.UpgradeComposeFile
+	logger.AppLogger().Debugf("dispose upgrade ComposeFile, f:%v", f)
+	composeFileContent := res.GetContentUpgradeComposeFile()
+	err := fileutil.WriteToFile(f, composeFileContent, true)
+	if err != nil {
+		logger.AppLogger().Errorf("write upgrade ComposeFile err:%v", err)
+		return
+	}
+}
+
+func replaceRandomPasswordAndPortPlaceholder(composeFileContent []byte) []byte {
+	logger.AppLogger().Debugf("replaceRandomPasswordAndPortPlaceholder")
+
+	randstr := ""
+	if fileutil.IsFileExist(config.Config.Box.RandDockercomposePassword) {
+
+		b, err := fileutil.ReadFromFile(config.Config.Box.RandDockercomposePassword)
+		if err != nil {
+			logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, ReadFromFile %v err: %v",
+				config.Config.Box.RandDockercomposePassword, err)
+		} else {
+			randstr = string(b)
+		}
+	}
+	if len(randstr) < 2 {
+		// 替换成随机密码
+		randstr = rand(16)
+		err := fileutil.WriteToFile(config.Config.Box.RandDockercomposePassword, []byte(randstr), true)
+		if err != nil {
+			logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, WriteToFile %v err: %v",
+				config.Config.Box.RandDockercomposePassword, err)
+		}
+	}
+	logger.AppLogger().Debugf("replaceRandomPasswordAndPortPlaceholder, randstr:%v", randstr)
+	composeFileContent = []byte(strings.ReplaceAll(string(composeFileContent), "placeholder_mysecretpassword", randstr))
+
+	randRedisPort := ""
+	if fileutil.IsFileExist(config.Config.Box.RandDockercomposeRedisPort) {
+
+		b, err := fileutil.ReadFromFile(config.Config.Box.RandDockercomposeRedisPort)
+		if err != nil {
+			logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, ReadFromFile %v err: %v",
+				config.Config.Box.RandDockercomposeRedisPort, err)
+		} else {
+			randRedisPort = string(b)
+			if err != nil {
+				logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, strconv.Atoi %v err: %v",
+					string(b), err)
+			}
+		}
+	}
+	if len(randRedisPort) < 2 {
+		// 替换成随机端口号
+		randRedisPort = randInt(19000, 19999) // redis 端口号在一个区间内随机生成
+		err := fileutil.WriteToFile(config.Config.Box.RandDockercomposeRedisPort, []byte(randRedisPort), true)
+		if err != nil {
+			logger.AppLogger().Errorf("replaceRandomPasswordAndPortPlaceholder, WriteToFile %v err: %v",
+				config.Config.Box.RandDockercomposeRedisPort, err)
+		}
+	}
+
+	i := strings.Index(string(composeFileContent), "placeholder_6379")
+	logger.AppLogger().Debugf("replaceRandomPasswordAndPortPlaceholder, randRedisPort:%v, strings.Index return :%v", randRedisPort, i)
+
+	composeFileContent = []byte(strings.ReplaceAll(string(composeFileContent), "placeholder_6379", randRedisPort))
+
+	// 更新自身连接 redis 的配置。
+	addrSplit := strings.Split(config.Config.Redis.Addr, ":")
+	if len(addrSplit) > 1 {
+		config.UpdateRedisConfig(addrSplit[0]+":6379", randstr)
+	} else {
+		config.UpdateRedisConfig("127.0.0.1:"+randRedisPort, randstr)
+	}
+
+	return composeFileContent
+}
+
+func rand(length int) string {
+	str := "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	bytes := []byte(str)
+	result := []byte{}
+	r := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < length; i++ {
+		result = append(result, bytes[r.Intn(len(bytes))])
+	}
+	return string(result)
+}
+
+func randInt(min int, max int) string {
+	math_rand.Seed(time.Now().UnixNano())
+	r := math_rand.Intn(max-min) + min
+	return fmt.Sprintf("%v", r)
+}

--- a/biz/model/device/info.go
+++ b/biz/model/device/info.go
@@ -89,8 +89,8 @@ func (b *DeviceInfo) SetAllInfo() error {
 	// 方式2: 根据硬件生成
 	btId, err := deviceid.GetBtId(config.Config.Box.CpuIdStoreFile, config.Config.Box.SnNumberStoreFile)
 	if err != nil {
-		err1 := fmt.Errorf("GET GetRPIBtId failed, no btid now, err:%v", err)
-		logger.AppLogger().Warnf("%v", err1)
+		logger.AppLogger().Warnf("GetBtId failed in SetAllInfo, fallback to generated btid, err:%v", err)
+		btId = getFallbackBtId()
 	}
 	boxUuid, err := deviceid.GetProductId(config.Config.Box.CpuIdStoreFile)
 	if err != nil {
@@ -123,8 +123,8 @@ func setDeviceInitData() error {
 	// 方式2: 根据硬件生成
 	btId, err := deviceid.GetBtId(config.Config.Box.CpuIdStoreFile, config.Config.Box.SnNumberStoreFile)
 	if err != nil {
-		err1 := fmt.Errorf("GET GetRPIBtId failed, no btid now, err:%v", err)
-		logger.AppLogger().Warnf("%v", err1)
+		logger.AppLogger().Warnf("GetBtId failed in setDeviceInitData, fallback to generated btid, err:%v", err)
+		btId = getFallbackBtId()
 	}
 	boxUuid, err := deviceid.GetProductId(config.Config.Box.CpuIdStoreFile)
 	if err != nil {
@@ -190,17 +190,21 @@ func GetQrCode() string {
 	if device_ability.GetAbilityModel().DeviceModelNumber >= device_ability.SN_SUPPORTED_FROM_MODEL_NUMBER {
 		snNumber, err := deviceid.GetSnNumber(config.Config.Box.SnNumberStoreFile)
 		if err != nil {
-			err1 := fmt.Errorf("failed GetSnNumber, err:%v", err)
-			// logger.AppLogger().Debugf("%v", err1)
-			return err1.Error()
+			logger.AppLogger().Warnf("GetQrCode failed GetSnNumber, fallback to generated sn, err:%v", err)
+			snNumber = getFallbackSnNumber()
+			if len(strings.TrimSpace(snNumber)) == 0 {
+				return getFallbackQrCodeByBtId()
+			}
 		}
 		return fmt.Sprintf("%v?sn=%v", UrlQrCodeDomain, snNumber)
 	} else if device_ability.GetAbilityModel().DeviceModelNumber <= device_ability.SN_GEN_CLOUD_DOCKER {
 		snNumber, err := deviceid.GetSnNumber(config.Config.Box.SnNumberStoreFile)
 		if err != nil {
-			err1 := fmt.Errorf("failed GetSnNumber, err:%v", err)
-			// logger.AppLogger().Debugf("%v", err1)
-			return err1.Error()
+			logger.AppLogger().Warnf("GetQrCode failed GetSnNumber in docker mode, fallback to generated sn, err:%v", err)
+			snNumber = getFallbackSnNumber()
+			if len(strings.TrimSpace(snNumber)) == 0 {
+				return getFallbackQrCodeByBtId()
+			}
 		}
 		logger.AppLogger().Debugf("GetQrCode, snNumber:%v", snNumber)
 
@@ -240,6 +244,40 @@ func GetQrCode() string {
 		}
 		return fmt.Sprintf("%v?btid=%v", UrlQrCodeDomain, btId)
 	}
+}
+
+func getFallbackBtId() string {
+	btId, err := deviceid.GetBtId(config.Config.Box.CpuIdStoreFile, config.Config.Box.SnNumberStoreFile)
+	if err == nil && len(strings.TrimSpace(btId)) > 0 {
+		return btId
+	}
+	productId, pErr := deviceid.GetProductId(config.Config.Box.CpuIdStoreFile)
+	if pErr != nil || len(strings.TrimSpace(productId)) == 0 {
+		logger.AppLogger().Warnf("fallback btid generation failed, GetProductId err:%v", pErr)
+		return ""
+	}
+	// keep generated btid in the same 16-char hash shape.
+	return deviceid.HashHex(productId)
+}
+
+func getFallbackQrCodeByBtId() string {
+	btId := getFallbackBtId()
+	if len(strings.TrimSpace(btId)) == 0 {
+		return UrlQrCodeDomain
+	}
+	return fmt.Sprintf("%v?btid=%v", UrlQrCodeDomain, btId)
+}
+
+func getFallbackSnNumber() string {
+	productId, err := deviceid.GetProductId(config.Config.Box.CpuIdStoreFile)
+	if err != nil || len(strings.TrimSpace(productId)) == 0 {
+		logger.AppLogger().Warnf("fallback sn generation failed, GetProductId err:%v", err)
+		return ""
+	}
+	if len(productId) >= 16 {
+		return strings.ToUpper(productId[:16])
+	}
+	return strings.ToUpper(productId)
 }
 
 func GetDeviceInfo() *DeviceInfo {

--- a/biz/model/device/internet_service_config.go
+++ b/biz/model/device/internet_service_config.go
@@ -17,7 +17,6 @@ package device
 import (
 	"agent/config"
 	"agent/utils/logger"
-	"fmt"
 	"sync"
 
 	"github.com/dungeonsnd/gocom/file/fileutil"
@@ -33,10 +32,10 @@ var lock sync.Mutex
 func init() {
 	c = &InternetServiceConfig{EnableInternetAccess: true}
 	if !fileutil.IsFileExist(config.Config.Box.InternetServiceConfigFile) {
-		fmt.Printf("InternetServiceConfig file not exist, %v \n", config.Config.Box.InternetServiceConfigFile)
+		logger.AppLogger().Infof("InternetServiceConfig file not exist, create default: %v", config.Config.Box.InternetServiceConfigFile)
 		writeToFile()
 	} else {
-		fmt.Printf("InternetServiceConfig file exist, %v \n", config.Config.Box.InternetServiceConfigFile)
+		logger.AppLogger().Infof("InternetServiceConfig file exists: %v", config.Config.Box.InternetServiceConfigFile)
 	}
 	readFromFile()
 }

--- a/biz/model/did/document_storage.go
+++ b/biz/model/did/document_storage.go
@@ -45,16 +45,14 @@ func init() {
 	go func() {
 		spaceKeyPri, spaceKeyPub, err := rsa.GenRsaKey(2048)
 		if err != nil {
-			fmt.Printf("\ninit GenRsaKey, spaceKey err:%v\n", err)
-			logger.AppLogger().Debugf("init GenRsaKey, spaceKey err:%v", err)
+			logger.AppLogger().Warnf("init GenRsaKey, spaceKey err:%v", err)
 		}
 		preGeneratedSpaceKeyPri = spaceKeyPri
 		preGeneratedSpaceKeyPub = spaceKeyPub
 
 		passwordKeyPri, passwordKeyPub, err := rsa.GenRsaKey(2048)
 		if err != nil {
-			fmt.Printf("\ninit GenRsaKey, passwordKey err:%v\n", err)
-			logger.AppLogger().Debugf("init GenRsaKey, passwordKey err:%v", err)
+			logger.AppLogger().Warnf("init GenRsaKey, passwordKey err:%v", err)
 		}
 		preGeneratedPasswordKeyPri = passwordKeyPri
 		preGeneratedPasswordKeyPub = passwordKeyPub
@@ -170,7 +168,7 @@ func getEncryptedPrivatePasswordKey(levelDBTrans *leveldb.Trans, aoId string) ([
 			leveldb.KNameOfPasswordRSAPri(aoId), err)
 		return nil, exist, err
 	}
-	fmt.Printf("\ngetPasswordKey, leveldb.Has:%v, err:%v\n",
+	logger.AppLogger().Debugf("getPasswordKey, leveldb.Has:%v, err:%v",
 		leveldb.KNameOfPasswordRSAPri(aoId), err)
 
 	var encryptedPriKeyBytes []byte

--- a/biz/service/call/call_micro_service.go
+++ b/biz/service/call/call_micro_service.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -38,7 +39,19 @@ import (
 	"github.com/dungeonsnd/gocom/encrypt/random"
 )
 
+func normalizeInternalServiceURL(raw string) string {
+	// In single-docker mode, loopback points to the agent container itself.
+	// Gateway must be reached by service name over compose network.
+	if os.Getenv("AOSPACE_SINGLE_DOCKER_MODE") == "true" && os.Getenv("AOSPACE_DATADIR") != "" {
+		u := strings.ReplaceAll(raw, "localhost:8080", "aospace-gateway:8080")
+		u = strings.ReplaceAll(u, "127.0.0.1:8080", "aospace-gateway:8080")
+		return u
+	}
+	return raw
+}
+
 func CallServiceByPost(url string, headers map[string]string, req, rsp interface{}) error {
+	url = normalizeInternalServiceURL(url)
 
 	if headers == nil {
 		headers = map[string]string{"Request-Id": random.GenUUID()}
@@ -57,6 +70,8 @@ func CallServiceByPost(url string, headers map[string]string, req, rsp interface
 }
 
 func CallServiceByGet(url string, headers map[string]string, req, rsp interface{}) error {
+	url = normalizeInternalServiceURL(url)
+
 	if headers == nil {
 		headers = map[string]string{"Request-Id": random.GenUUID()}
 	}
@@ -81,6 +96,8 @@ func CallServiceByForm(method, url string, reqMap map[string]string, rsp interfa
 }
 
 func CallServiceByFormStr(method, url string, reqStr string, rsp interface{}) (*http.Response, error) {
+	url = normalizeInternalServiceURL(url)
+
 	if len(method) < 1 {
 		method = "POST"
 	}

--- a/biz/service/pair/wifi_operation.go
+++ b/biz/service/pair/wifi_operation.go
@@ -19,6 +19,7 @@ import (
 	"agent/config"
 	"agent/utils/rpi/network"
 	"fmt"
+	"net"
 	"sort"
 	"strconv"
 	"strings"
@@ -243,6 +244,10 @@ func GetConnectedNetwork() []*dtopair.Network {
 
 			arr := strings.Split(string(ipaddr), ":")
 			if len(arr) >= 2 {
+				if !isValidLanOrRoutableHost(arr[0]) {
+					logger.AppLogger().Warnf("GetConnectedNetwork skip loopback/invalid host from HostIpFile: %v", arr[0])
+					return []*dtopair.Network{}
+				}
 				logger.AppLogger().Debugf("GetConnectedNetwork, IsFileExist, Ip:%v", string(arr[0]))
 				ret := make([]*dtopair.Network, 0)
 				ret = append(ret, &dtopair.Network{Ip: arr[0], Wire: true, WifiName: "",
@@ -270,6 +275,10 @@ func GetConnectedNetwork() []*dtopair.Network {
 		if len(arr) > 1 {
 			ip = arr[0]
 		}
+		if !isValidLanOrRoutableHost(ip) {
+			logger.AppLogger().Warnf("GetConnectedNetwork skip loopback/invalid ip from network iface: %v", ip)
+			continue
+		}
 
 		n := &dtopair.Network{Ip: ip, Wire: true,
 			WifiName: v.GeneralDevice,
@@ -287,4 +296,22 @@ func GetConnectedNetwork() []*dtopair.Network {
 	}
 
 	return rt
+}
+
+func isValidLanOrRoutableHost(host string) bool {
+	h := strings.TrimSpace(strings.Trim(host, "[]"))
+	if h == "" {
+		return false
+	}
+	if strings.EqualFold(h, "localhost") {
+		return false
+	}
+	ip := net.ParseIP(h)
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() {
+		return false
+	}
+	return true
 }

--- a/biz/web/handler/device/info.go
+++ b/biz/web/handler/device/info.go
@@ -212,7 +212,7 @@ func cutOSVersion(rawVersion string) string {
 		suffix := ".aarch64"
 		r, err := regexp.Compile(prefix + ".*" + suffix)
 		if err != nil {
-			fmt.Printf("failed regexp.Compile r, err:%v\n", err)
+			logger.AppLogger().Warnf("failed regexp.Compile for os version parser: %v", err)
 			return ""
 		}
 		version := r.FindString(rawVersion)
@@ -240,7 +240,7 @@ func parseImagesVersion(s string) ([]device.ServiceVersion, error) {
 		if err != nil {
 			return serviceVersion, fmt.Errorf("parseImagesVersion, failed JsonDecode, err:%v", err)
 		} else {
-			fmt.Printf("%+v\n\n", obj)
+			logger.AppLogger().Debugf("parseImagesVersion item: %+v", obj)
 			serviceVersion = append(serviceVersion, obj)
 		}
 	}

--- a/biz/web/handler/status/info.go
+++ b/biz/web/handler/status/info.go
@@ -29,7 +29,9 @@ import (
 	"agent/biz/model/dto/status"
 	"agent/config"
 	"fmt"
+	"net"
 	"net/http"
+	"strings"
 
 	"agent/utils/logger"
 	"github.com/dungeonsnd/gocom/encrypt/random"
@@ -74,14 +76,18 @@ func Info(c *gin.Context) {
 
 	abilityModel := device_ability.GetAbilityModel()
 	if abilityModel.RunInDocker {
-		err := fileutil.WriteToFile(config.Config.Box.HostIpFile, []byte(c.Request.Host), true)
-		if err != nil {
-			err1 := fmt.Errorf("failed write HostIpFile, %+v", err)
-			logger.AppLogger().Debugf("info POST, %+v", err1)
-			c.JSON(http.StatusOK, dto.BaseRspStr{Code: dto.AgentCodeServerErrorStr,
-				RequestId: random.GenUUID(),
-				Message:   err1.Error()})
-			return
+		if persistableHost(c.Request.Host) {
+			err := fileutil.WriteToFile(config.Config.Box.HostIpFile, []byte(c.Request.Host), true)
+			if err != nil {
+				err1 := fmt.Errorf("failed write HostIpFile, %+v", err)
+				logger.AppLogger().Debugf("info POST, %+v", err1)
+				c.JSON(http.StatusOK, dto.BaseRspStr{Code: dto.AgentCodeServerErrorStr,
+					RequestId: random.GenUUID(),
+					Message:   err1.Error()})
+				return
+			}
+		} else {
+			logger.AppLogger().Debugf("skip writing HostIpFile for request host:%q", c.Request.Host)
 		}
 		result.QrCode = device.GetQrCode()
 	}
@@ -90,4 +96,30 @@ func Info(c *gin.Context) {
 		Message:   "OK",
 		RequestId: random.GenUUID(),
 		Results:   result})
+}
+
+func persistableHost(hostport string) bool {
+	host := strings.TrimSpace(hostport)
+	if host == "" {
+		return false
+	}
+	parsedHost := host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		parsedHost = h
+	}
+	parsedHost = strings.TrimSpace(strings.Trim(parsedHost, "[]"))
+	if parsedHost == "" {
+		return false
+	}
+	if strings.EqualFold(parsedHost, "localhost") {
+		return false
+	}
+	ip := net.ParseIP(parsedHost)
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() {
+		return false
+	}
+	return true
 }

--- a/biz/web/http_server.go
+++ b/biz/web/http_server.go
@@ -46,10 +46,16 @@ func Start() {
 	// start internal web server
 	if strings.EqualFold(os.Getenv(config.Config.Box.RunInDocker.AoSpaceSingleDockerModeEnv), "true") {
 		go internalWebServer.Start()
-	} else {
-		docker.SubscribeAsyncDockerNetwork(func(status int) {
-			go internalWebServer.Start()
-		})
+		return
 	}
+
+	if !config.Config.EnableDockerManage {
+		go internalWebServer.Start()
+		return
+	}
+
+	docker.SubscribeAsyncDockerNetwork(func(status int) {
+		go internalWebServer.Start()
+	})
 
 }

--- a/biz/web/routers/router.go
+++ b/biz/web/routers/router.go
@@ -43,13 +43,15 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spkg/zipfs"
 )
 
 func ExternalRouter() *gin.Engine {
-	router := gin.Default()
+	router := gin.New()
+	router.Use(gin.Recovery(), accessLogMiddleware("external"))
 
 	addHtmlZipHandler(router)
 
@@ -138,7 +140,8 @@ func ExternalRouter() *gin.Engine {
 }
 
 func InternalRouter() *gin.Engine {
-	router := gin.Default()
+	router := gin.New()
+	router.Use(gin.Recovery(), accessLogMiddleware("internal"))
 
 	v1 := router.Group("/agent/v1/api")
 	{
@@ -196,6 +199,47 @@ func InternalRouter() *gin.Engine {
 	return router
 }
 
+func accessLogMiddleware(server string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		requestURI := c.Request.URL.Path
+		if c.Request.URL.RawQuery != "" {
+			requestURI += "?" + c.Request.URL.RawQuery
+		}
+
+		c.Next()
+
+		status := c.Writer.Status()
+		latencyMs := time.Since(start).Milliseconds()
+		requestId := c.GetHeader("Request-Id")
+		errMsg := c.Errors.String()
+
+		fields := []interface{}{
+			"server", server,
+			"method", c.Request.Method,
+			"uri", requestURI,
+			"status", status,
+			"latency_ms", latencyMs,
+			"client_ip", c.ClientIP(),
+			"request_id", requestId,
+			"user_agent", c.Request.UserAgent(),
+			"size", c.Writer.Size(),
+		}
+		if errMsg != "" {
+			fields = append(fields, "errors", errMsg)
+		}
+
+		switch {
+		case status >= http.StatusInternalServerError:
+			logger.AccessLogger().Errorw("http request", fields...)
+		case status >= http.StatusBadRequest:
+			logger.AccessLogger().Warnw("http request", fields...)
+		default:
+			logger.AccessLogger().Infow("http request", fields...)
+		}
+	}
+}
+
 func addHtmlZipHandler(router *gin.Engine) error {
 
 	buf := res.GetContentStaticHtmlZip()
@@ -203,7 +247,6 @@ func addHtmlZipHandler(router *gin.Engine) error {
 	fs, err := zipfs.NewFromReaderAt(reader, int64(len(buf)), nil)
 	if err != nil {
 		err1 := fmt.Errorf("Failed NewFromReaderAt, err: %v", err)
-		fmt.Printf("%+v\n", err1)
 		logger.AppLogger().Errorf("%+v", err1)
 	}
 

--- a/biz/web/routers/routes_contract_test.go
+++ b/biz/web/routers/routes_contract_test.go
@@ -1,0 +1,91 @@
+package routers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func routeSet(routes []gin.RouteInfo) map[string]struct{} {
+	out := make(map[string]struct{}, len(routes))
+	for _, route := range routes {
+		out[fmt.Sprintf("%s %s", route.Method, route.Path)] = struct{}{}
+	}
+	return out
+}
+
+func mustContainAll(t *testing.T, registered map[string]struct{}, expected []string) {
+	t.Helper()
+	for _, api := range expected {
+		if _, ok := registered[api]; !ok {
+			t.Fatalf("missing route: %s", api)
+		}
+	}
+}
+
+func TestExternalRouter_RegistersExpectedAPIs(t *testing.T) {
+	registered := routeSet(ExternalRouter().Routes())
+	expected := []string{
+		"POST /agent/v1/api/initial",
+		"POST /agent/v1/api/pairing",
+		"POST /agent/v1/api/pubkeyexchange",
+		"POST /agent/v1/api/keyexchange",
+		"POST /agent/v1/api/setpassword",
+		"GET /agent/v1/api/device/ability",
+		"POST /agent/v1/api/admin/revoke",
+		"GET /agent/v1/api/pair/net/localips",
+		"GET /agent/v1/api/pair/net/netconfig",
+		"GET /agent/v1/api/pair/init",
+		"GET /agent/v1/api/bind/init",
+		"POST /agent/v1/api/bind/com/start",
+		"GET /agent/v1/api/bind/com/progress",
+		"POST /agent/v1/api/bind/space/create",
+		"POST /agent/v1/api/bind/internet/service/config",
+		"GET /agent/v1/api/bind/internet/service/config",
+		"POST /agent/v1/api/bind/password/verify",
+		"POST /agent/v1/api/bind/revoke",
+		"GET /agent/v1/api/space/ready/check",
+		"POST /agent/v1/api/network/config",
+		"GET /agent/v1/api/network/config",
+		"POST /agent/v1/api/network/ignore",
+		"POST /agent/v1/api/passthrough",
+		"POST /agent/v1/api/switch",
+		"GET /agent/v1/api/switch/status",
+		"GET /agent/v1/cert/get",
+		"GET /agent/v1/api/did/document",
+		"PUT /agent/v1/api/did/document/password",
+		"PUT /agent/v1/api/did/document/method",
+		"GET /agent/status",
+		"GET /agent/info",
+	}
+	mustContainAll(t, registered, expected)
+}
+
+func TestInternalRouter_RegistersExpectedAPIs(t *testing.T) {
+	registered := routeSet(InternalRouter().Routes())
+	expected := []string{
+		"GET /agent/v1/api/device/info",
+		"GET /agent/v1/api/device/version",
+		"GET /agent/v1/api/device/ability",
+		"GET /agent/v1/api/device/localips",
+		"GET /agent/v1/api/device/netconfig",
+		"GET /agent/v1/api/upgrade/config",
+		"POST /agent/v1/api/upgrade/config",
+		"POST /agent/v1/api/upgrade/download",
+		"POST /agent/v1/api/upgrade/install",
+		"GET /agent/v1/api/upgrade/status",
+		"POST /agent/v1/api/network/config",
+		"GET /agent/v1/api/network/config",
+		"POST /agent/v1/api/network/ignore",
+		"POST /agent/v1/api/system/shutdown",
+		"POST /agent/v1/api/system/reboot",
+		"GET /agent/v1/api/cert/get",
+		"POST /agent/v1/api/bind/internet/service/config",
+		"GET /agent/v1/api/bind/internet/service/config",
+		"GET /agent/v1/api/did/document",
+		"PUT /agent/v1/api/did/document/password",
+		"PUT /agent/v1/api/did/document/method",
+	}
+	mustContainAll(t, registered, expected)
+}

--- a/biz/web/routers/server.go
+++ b/biz/web/routers/server.go
@@ -40,8 +40,7 @@ type HttpServer interface {
 
 // Start external web server start
 func (w *ExternalWebServer) Start() {
-	fmt.Printf("startWebServer \n")
-	logger.AppLogger().Infof("startWebServer")
+	logger.AppLogger().Infof("startWebServer, listen=%v", config.Config.Web.DefaultListenAddr)
 
 	if gin.Mode() == gin.DebugMode {
 		w.Router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
@@ -49,14 +48,13 @@ func (w *ExternalWebServer) Start() {
 	err := w.Router.Run(config.Config.Web.DefaultListenAddr)
 	if err != nil {
 		logger.AppLogger().Errorf("Failed startWebServer, err: %v", err)
-		os.Exit(-1)
+		os.Exit(2)
 	}
 	return
 }
 
 // Start internal web server start
 func (w *InternalWebServer) Start() {
-	fmt.Printf("startWebServerDockerLocal \n")
 	logger.AppLogger().Infof("startWebServerDockerLocal")
 
 	if gin.Mode() == gin.DebugMode {
@@ -73,7 +71,6 @@ func (w *InternalWebServer) Start() {
 	err := w.Router.Run(localListenAddr)
 	if err != nil {
 		err1 := fmt.Errorf("Failed startWebServerDockerLocal using %v, err: %v", localListenAddr, err)
-		fmt.Printf("%+v\n", err1)
 		logger.AppLogger().Errorf("%+v", err1)
 		// os.Exit(0) // 可能不是致命的
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ package config
 import (
 	hardware_util "agent/utils/hardware"
 	"flag"
-	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -39,6 +39,7 @@ var Config = struct {
 	DebugMode                                 bool `default:"false"` // 调试模式。会控制是否打开 swagger 等。
 	PlatformEnabled                           bool `default:"false"` // 是否启用平台相关能力（注册、升级、互联网通道等）
 	OverwriteDockerCompose                    bool `default:"true"`  // 启动时是否覆盖 docker-compose.yml。"true" 表示覆盖。
+	EnableDockerManage                        bool `default:"true"`  // 是否由 space-agent 管理 docker 微服务（false 时仅提供配对/API 能力）
 	EnableSecurityChip                        bool `default:"true"`  // 是否启用加密芯片。
 	EncryptLanSessionData                     bool `default:"true"`  // 加密局域网通信数据
 	EnableBackupRestoreSupportWhenRunAsDocker bool `default:"false"` // 容器化部署时, 是否启动备份恢复功能.
@@ -527,6 +528,27 @@ func modifyConfigWhenRunInDocker() {
 			}
 			Config.GateWay.LanPort = 12841
 			Config.GateWay.TlsLanPort = 18569
+		} else if !Config.EnableDockerManage {
+			addr := []*string{&Config.AliveChecker.GateWay.UrlGateway,
+				&Config.GateWay.Revoke.Url,
+				&Config.GateWay.APIRoot.Url,
+				&Config.Account.User.Url,
+				&Config.Account.Member.Url,
+				&Config.Account.AdminCreate.Url,
+				&Config.Account.SpaceAdmin.Url,
+				&Config.Account.NetworkChannelInfo.Url,
+				&Config.Account.NetworkChannelWan.Url,
+				&Config.Account.AdminSetPassword.Url,
+				&Config.Account.AdminPasswordCheck.Url,
+				&Config.Account.AdminRevoke.Url,
+				&Config.Account.AdminInitial.Url,
+				&Config.Account.Migrate.Url,
+				&Config.Redis.Addr,
+				&Config.GateWay.SwitchPlatform.Url}
+			for _, v := range addr {
+				*v = strings.ReplaceAll(*v, "localhost:8080", "aospace-gateway:8080")
+				*v = strings.ReplaceAll(*v, "127.0.0.1:6379", "aospace-redis:6379")
+			}
 		} else {
 			Config.EnvDefaultVal.SYSTEM_AGENT_URL_DEVICE_INFO = "http://localhost:5680/agent/v1/api/device/info"
 			Config.EnvDefaultVal.SYSTEM_AGENT_URL_BASE = "http://localhost:5680/agent/v1/api"
@@ -551,11 +573,11 @@ func createLogFileDir() {
 func readExistingConfigFile(f string) {
 	b, err := fileutil.ReadFromFile(f)
 	if err != nil {
-		fmt.Printf("ReadFromFile config %v fail, err: %+v\n\n", f, err)
+		log.Printf("read config file failed: file=%v, err=%+v", f, err)
 	} else {
 		err1 := yaml.Unmarshal(b, &Config)
 		if err1 != nil {
-			fmt.Printf("Unmarshal config file %v fail, err: %+v\n\n", f, err1)
+			log.Printf("unmarshal config file failed: file=%v, err=%+v", f, err1)
 		}
 	}
 }
@@ -563,8 +585,7 @@ func readExistingConfigFile(f string) {
 func removeExistingConfigFile(f string) {
 	err := fileutil.WriteToFile(f, []byte{}, true)
 	if err != nil {
-		fmt.Printf("failed removeExistingConfigFile, WriteToFile file:%v, err: %+v\n",
-			f, err)
+		log.Printf("remove existing config file failed: file=%v, err=%+v", f, err)
 		return
 	}
 }
@@ -572,7 +593,7 @@ func removeExistingConfigFile(f string) {
 func writeDefaultConfigFile(f string) {
 	out, err := yaml.Marshal(Config)
 	if err != nil {
-		fmt.Printf("failed  yaml.Marshal: %+v\n", err)
+		log.Printf("marshal default config failed: err=%+v", err)
 		return
 	}
 	// fmt.Printf("@@@@ DefaultConfigFile:\n%+v\n\n", string(out))

--- a/main.go
+++ b/main.go
@@ -35,7 +35,6 @@ import (
 	"agent/biz/service/upgrade"
 	"agent/biz/web"
 	"agent/utils/logger"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -57,17 +56,21 @@ func main() {
 
 	logger.AppLogger().Infof("================[%v Started] [system-agent version:%v]================",
 		os.Args[0], config.Version+"-"+config.VersionNumber)
-
-	fmt.Printf("AoLogDirBase:%+v\n", config.Config.Log.AoLogDirBase)
-	fmt.Printf("singleDockerModeEnv:%+v\n", os.Getenv(config.Config.Box.RunInDocker.AoSpaceSingleDockerModeEnv))
+	logger.AppLogger().Infof("startup config: AoLogDirBase=%v, singleDockerModeEnv=%v, platformEnabled=%v, dockerManage=%v",
+		config.Config.Log.AoLogDirBase,
+		os.Getenv(config.Config.Box.RunInDocker.AoSpaceSingleDockerModeEnv),
+		config.Config.PlatformEnabled,
+		config.Config.EnableDockerManage)
 
 	if err := AgentCmd.Execute(); err != nil {
-		fmt.Println(err)
+		logger.AppLogger().Errorf("agent command execute failed: %v", err)
 		os.Exit(1)
 	}
+	logger.AppLogger().Infof("initializing device identity and keys")
 	device.InitDeviceInfo()
 	device.InitDeviceKey()
 	clientinfo.InitClientInfo()
+	logger.AppLogger().Infof("device identity initialized")
 
 	if !strings.EqualFold(os.Getenv(config.Config.Box.RunInDocker.AoSpaceSingleDockerModeEnv), "true") && config.Config.PlatformEnabled {
 		go platform.InitPlatformAbility()
@@ -76,15 +79,24 @@ func main() {
 	}
 
 	// 启动 web/http api 服务
+	logger.AppLogger().Infof("starting web api services")
 	web.Start()
+	logger.AppLogger().Infof("web api services started")
 
 	// 启动 docker 微服务创建或启动
-	if strings.EqualFold(os.Getenv(config.Config.Box.RunInDocker.AoSpaceSingleDockerModeEnv), "true") {
-		docker.MigrateFileStorageData()
+	if config.Config.EnableDockerManage {
+		logger.AppLogger().Infof("starting docker services management")
+		if strings.EqualFold(os.Getenv(config.Config.Box.RunInDocker.AoSpaceSingleDockerModeEnv), "true") {
+			docker.MigrateFileStorageData()
+		} else {
+			docker.Start()
+		}
+		logger.AppLogger().Infof("docker services management initialized")
 	} else {
-		docker.Start()
+		logger.AppLogger().Infof("Docker management disabled by config")
 	}
 	alivechecker.Start()
+	logger.AppLogger().Infof("alivechecker started")
 
 	// 检测是否需要发送升级推送
 	if !strings.EqualFold(os.Getenv(config.Config.Box.RunInDocker.AoSpaceSingleDockerModeEnv), "true") && config.Config.PlatformEnabled {
@@ -93,11 +105,13 @@ func main() {
 
 	// 日志目录监控
 	log_dir_monitor.Start()
+	logger.AppLogger().Infof("log directory monitor started")
 
 	if err := leveldb.OpenDB(); err != nil {
-		fmt.Printf("\nFailed leveldb.OpenDB, err:%v\n", err)
-		os.Exit(0)
+		logger.LevelDBLogger().Errorf("failed leveldb.OpenDB: %v", err)
+		os.Exit(2)
 	}
+	logger.LevelDBLogger().Infof("leveldb opened successfully")
 
 	quitChan := make(chan os.Signal)
 	signal.Notify(quitChan, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM,
@@ -106,7 +120,7 @@ func main() {
 	for s := range quitChan {
 		switch s {
 		case syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT:
-			fmt.Printf("signal %v\n", s)
+			logger.AppLogger().Infof("receive signal: %v", s)
 			GracefullExit()
 		case syscall.SIGUSR1:
 			// fmt.Println("usr1 signal", s)

--- a/utils/ble/server.go
+++ b/utils/ble/server.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 /*
  * @Author: wenchao
  * @Date: 2021-11-10 10:44:41
@@ -54,7 +53,6 @@ func Start(serviceName_, serviceUUID_ string, onRecvCb service.OnRecvCallbackFun
 	// fmt.Printf("before gatt.NewDevice \n")
 	d, err := gatt.NewDevice(option.DefaultServerOptions...)
 	if err != nil {
-		fmt.Printf("Failed to open device, err: %s\n", err)
 		logger.AppLogger().Warnf("Failed to open device, err: %v", err)
 		return fmt.Errorf("Failed to open device, err: %s", err)
 	}
@@ -63,13 +61,11 @@ func Start(serviceName_, serviceUUID_ string, onRecvCb service.OnRecvCallbackFun
 	// Register optional handlers.
 	d.Handle(
 		gatt.CentralConnected(func(c gatt.Central) {
-			fmt.Printf("Connect, ID:%v, MTU:%v, certral:%v\n", c.ID(), c.MTU(), c)
 			mtu = c.MTU()
 			logger.AppLogger().Infof("#### BLUETOOTH Connect, ID:%v, MTU:%v, certral:%v", c.ID(), c.MTU(), c)
 			service.SetConnected(true)
 		}),
 		gatt.CentralDisconnected(func(c gatt.Central) {
-			fmt.Printf("Disconnect: ID:%v, certral:%v\n", c.ID(), c)
 			logger.AppLogger().Warnf("#### BLUETOOTH Disconnect, ID:%v, MTU:%v, certral:%v", c.ID(), c.MTU(), c)
 			service.SetConnected(false)
 		}),

--- a/utils/ble/service/gatt.go
+++ b/utils/ble/service/gatt.go
@@ -15,7 +15,7 @@
 package service
 
 import (
-	"log"
+	"agent/utils/logger"
 
 	"github.com/paypal/gatt"
 )
@@ -32,7 +32,7 @@ func NewGattService() *gatt.Service {
 	s.AddCharacteristic(attrServiceChangedUUID).HandleNotifyFunc(
 		func(r gatt.Request, n gatt.Notifier) {
 			go func() {
-				log.Printf("TODO: indicate client when the services are changed")
+				logger.AppLogger().Debugf("TODO: indicate client when the services are changed")
 			}()
 		})
 	return s

--- a/utils/deviceid/sn.go
+++ b/utils/deviceid/sn.go
@@ -15,10 +15,13 @@
 package deviceid
 
 import (
+	"agent/utils/logger"
 	"fmt"
 	"strconv"
 	"strings"
 
+	"github.com/dungeonsnd/gocom/encrypt/hash/sha256"
+	"github.com/dungeonsnd/gocom/encrypt/random"
 	"github.com/dungeonsnd/gocom/file/fileutil"
 )
 
@@ -40,23 +43,28 @@ func GetSnNumber(snNumberStoreFile string) (string, error) {
 	if fileutil.IsFileExist(snNumberStoreFile) {
 		// fmt.Printf("GetSnNumber,%v exist\n", snNumberStoreFile)
 		if content, err := fileutil.ReadFromFile(snNumberStoreFile); err != nil {
-			fmt.Printf("GetSnNumber, ReadFromFile err: %v\n", err)
+			logger.AppLogger().Warnf("GetSnNumber read file failed: file=%v, err=%v", snNumberStoreFile, err)
 			return "", err
 		} else {
 			return string(content), nil
 		}
 	} else if strings.EqualFold(currentChip(), RPI) || strings.EqualFold(currentChip(), RK3568Dev) {
-		fmt.Printf("GetSnNumber,%v not exist, so current hardware is chip:%v\n", snNumberStoreFile, currentChip())
+		logger.AppLogger().Warnf("GetSnNumber file not found on unsupported chip: file=%v, chip=%v", snNumberStoreFile, currentChip())
 		return "", fmt.Errorf("unsupported on this hardware platform")
 	} else {
-		fmt.Printf("GetSnNumber,%v not exist, so current hardware is rk's production\n", snNumberStoreFile)
+		logger.AppLogger().Infof("GetSnNumber file not found, fallback to vendor storage: file=%v", snNumberStoreFile)
 		sn, err := getVendorSnNumber()
 		if err != nil {
-			fmt.Printf("GetSnNumber, getVendorSnNumber err: %v\n", err)
-			return "", err
-		} else {
-			return sn, nil // 二代正式板
+			logger.AppLogger().Warnf("GetSnNumber vendor storage failed: err=%v", err)
+			// In dev/docker host mode there may be no vendor storage. Generate a stable fallback SN.
+			fallback := strings.ToUpper(sha256.HashHex([]byte(random.GenUUID()), 1)[:SnNumberLength])
+			if wErr := fileutil.WriteToFile(snNumberStoreFile, []byte(fallback), false); wErr != nil {
+				logger.AppLogger().Warnf("GetSnNumber write fallback sn failed: file=%v, err=%v", snNumberStoreFile, wErr)
+			}
+			logger.AppLogger().Warnf("GetSnNumber use generated fallback sn: %v", fallback)
+			return fallback, nil
 		}
+		return sn, nil // 二代正式板
 	}
 }
 

--- a/utils/docker/imp/dengineapi/container.go
+++ b/utils/docker/imp/dengineapi/container.go
@@ -16,6 +16,7 @@ package dengineapi
 
 import (
 	"agent/utils/docker/dockermodel"
+	"agent/utils/logger"
 	"context"
 	"fmt"
 	"github.com/docker/docker/api/types/filters"
@@ -109,7 +110,7 @@ func CreateContainer(cli *client.Client, req *CreateContainerReq) (string, error
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("ID: %s\n", body.ID)
+	logger.DockerLogger().Infof("container created: name=%v, id=%v, image=%v", req.ContainerName, body.ID, req.ImageName)
 	return body.ID, nil
 }
 

--- a/utils/docker/imp/dengineapi/image.go
+++ b/utils/docker/imp/dengineapi/image.go
@@ -16,6 +16,7 @@ package dengineapi
 
 import (
 	"agent/utils/docker/dockermodel"
+	"agent/utils/logger"
 	"bytes"
 	"context"
 	"fmt"
@@ -38,8 +39,7 @@ func PullImageWithoutAuth(cli *client.Client, imageName string) error {
 }
 
 func PullImageByAuthStr(cli *client.Client, imageName string, authStr string) error {
-
-	fmt.Printf(">>>> imageName: %v, authStr=%v \n", imageName, authStr)
+	logger.DockerLogger().Infof("pull image start: image=%v, has_auth=%v", imageName, authStr != "")
 
 	events, err := cli.ImagePull(context.Background(), imageName, types.ImagePullOptions{
 		All:           false,
@@ -54,8 +54,7 @@ func PullImageByAuthStr(cli *client.Client, imageName string, authStr string) er
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(events)
 	s := buf.String()
-	fmt.Printf("#### ImagePull return: %v\n", s)
-	// fmt.Println("image pull success")
+	logger.DockerLogger().Debugf("pull image response: image=%v, response_len=%v", imageName, len(s))
 	return nil
 }
 

--- a/utils/hardware/hardware.go
+++ b/utils/hardware/hardware.go
@@ -15,6 +15,7 @@
 package hardware
 
 import (
+	"agent/utils/logger"
 	"fmt"
 	"os"
 	"strings"
@@ -58,11 +59,7 @@ func RunningInDocker() bool {
 	// 由于其他方法在某些 OS 上有失效的可能性，暂时用用户传入的环境变量来判断。
 	envkey := "AOSPACE_DATADIR"
 	dataDir := os.Getenv(envkey)
-	if len(dataDir) > 0 {
-		fmt.Printf("RunningInDocker, dataDir:%v\n", dataDir)
-		return true
-	} else {
-		fmt.Printf("RunningInDocker==false, dataDir:%v\n", dataDir)
-		return false
-	}
+	inDocker := len(dataDir) > 0
+	logger.AppLogger().Debugf("RunningInDocker: %v, %v=%v", inDocker, envkey, dataDir)
+	return inDocker
 }


### PR DESCRIPTION
## Summary
  This PR improves space-agent observability and stability for simplified
  deployments, especially LAN-first and compose-driven scenarios.

  ## What Changed

  - Added structured HTTP access logs (method, URI, status, latency, client IP,
    request ID).
  - Replaced scattered fmt output with consistent logger-based messages.
  - Added EnableDockerManage to allow running agent APIs without forcing docker
    service orchestration.
  - Added URL normalization for internal service calls in single-docker mode
    (localhost -> compose service name).
  - Improved /agent/info host persistence with host validation (skip localhost/
    loopback/empty hosts).
  - Added fallback logic for BTID/SN/QR generation when hardware values are
    missing.
  - Added router contract tests to ensure key internal/external APIs remain
    registered.

  ## Why

  - Simplified deployment mode needs predictable routing and better logs for
    troubleshooting.
  - Existing behavior could bind to invalid loopback addresses in containerized
    scenarios.
  - Missing hardware identifiers should degrade gracefully instead of breaking
    bind/QR flows.

  ## Validation

  - Verified agent starts with improved startup/access logs.
  - Verified router contracts via routes_contract_test.go.
  - Verified LAN host handling and fallback identity generation paths in
    simplified deployment flows.

Generated-by: Codex